### PR TITLE
Talk Edit Form: Fix Bug in editing of Trainings

### DIFF
--- a/p3/forms.py
+++ b/p3/forms.py
@@ -22,6 +22,7 @@ TALK_DURATION = (
     (45, _('45 minutes inc Q&A')),
     (60, _('60 minutes inc Q&A')),
     (90, _('90 minutes inc Q&A')),
+    (240, _('240 minutes inc Q&A')),
 )
 
 TALK_TYPES = (


### PR DESCRIPTION
The list of accepted durations of the talk to be edited did not include the (fixed) duration for a training talks, i.e., `240` mins.
This caused the form to not be properly validated, thus not allowing any modifications at all (in case of trainings).