### PR TITLE
requirements: fix django-polymorphic issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,8 @@ django-tagging==0.3.1
 python-memcached==1.48
 django-filer==0.9.12
 cmsplugin-filer==0.10.2
+# ref https://github.com/divio/django-filer/issues/653
+django-polymorphic==0.7.2
 pytz
 Fabric
 django-crontab==0.4.2


### PR DESCRIPTION
With this commit we can use the pip native django-polimorphic without
our patch for the import issue. We must rollback to 0.7.2.

ref https://github.com/divio/django-filer/issues/653

**PLEASE TEST**
@C8E ^

fatta pr su master in quanto più avanti di develop