### PR TITLE
pycon_app: aggiungiamo endpoint per lo schedule per l'app

### DIFF
--- a/p3/urls.py
+++ b/p3/urls.py
@@ -44,6 +44,8 @@ urlpatterns += patterns('p3.views',
 
     url(r'^schedule/(?P<conference>[\w-]+)/my-schedule/$',
         'my_schedule', name='p3-schedule-my-schedule'),
+    url(r'^schedule/(?P<conference>[\w-]+)/app-schedule.ics$',
+        'app_schedule_ics', name='p3-schedule-app-schedule-ics'),
     url(r'^schedule/(?P<conference>[\w-]+)/my-schedule.ics$',
         'schedule_ics', name='p3-schedule-my-schedule-ics', kwargs={'mode': 'my-schedule'}),
 


### PR DESCRIPTION
ritorniamo lo schedule in json per l'applicazione ufficiale di pycon8,
nel caso ci fossero le credenziali in basicauth inviamo anche le preferenze
dell'utente autenticato (le stelline sullo schedule).

@cinghiale :pray: