### PR TITLE
ticket: non esplodiamo al salvataggio di un ticket

### DIFF
--- a/p3/admin.py
+++ b/p3/admin.py
@@ -85,7 +85,10 @@ class TicketConferenceAdmin(cadmin.TicketAdmin):
 
     def save_model(self, request, obj, form, change):
         obj.save()
-        p3c = obj.p3_conference
+        try:
+            p3c = obj.p3_conference
+        except models.TicketConference.DoesNotExist:
+            p3c = None
         if p3c is None:
             p3c = models.TicketConference(ticket=obj)
 


### PR DESCRIPTION
per qualche motivazione sconosciuta, al salvataggio del ticket viene cercata una
relazione inesistente. Catturando l'eccezione correttamente si riesce a modificare il
ticket senza ulteriori problemi