### PR TITLE
Fixed the profile page

### DIFF
--- a/p3/templates/assopy/profile.html
+++ b/p3/templates/assopy/profile.html
@@ -1,5 +1,5 @@
 {% extends "assopy/base.html" %}
-{% load assopy_tags i18n p3 conference static %}
+{% load assopy_tags i18n p3 static %}
 {% block ASSOPY_EXTRA_HEAD %}
     <script src="https://unpkg.com/jspdf@latest/dist/jspdf.min.js"></script>
     <script src="{% static 'p9/javascripts/pdfgenerator/cert_of_attendance_obf.js' %}"></script>

--- a/p3/templatetags/p3.py
+++ b/p3/templatetags/p3.py
@@ -654,3 +654,11 @@ def p3_voting_data(conference):
     results['groups'] = dict(groups)
     return results
 
+
+@fancy_tag(register, takes_context=True)
+def get_latest_conf_deadline(context, limit=None, not_expired=True):
+    try:
+        conf = ConferenceModels.Conference.objects.latest('code')
+        return [conf.name, conf.code, conf.conference_start, conf.conference_end, datetime.today().date()]
+    except IndexError:
+        return []


### PR DESCRIPTION
 Fixed the profile page by moving the templatetag 'get_latest_conf_deadline' in p3 template tag. This was an error during the last PR on this branch. I got confused with the dependencies in the src directory that are not tracked in the repo!