### PR TITLE
Remove city tax from the label

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -1846,7 +1846,7 @@ msgid "Add another"
 msgstr ""
 
 #: p3/templates/p3/cart.html:185
-msgid "Hotel reservations total (inc. VAT & city tax)"
+msgid "Hotel reservations total (inc. VAT)"
 msgstr ""
 
 #: p3/templates/p3/cart.html:188

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -1875,7 +1875,7 @@ msgid "Add another"
 msgstr ""
 
 #: p3/templates/p3/cart.html:185
-msgid "Hotel reservations total (inc. VAT & city tax)"
+msgid "Hotel reservations total (inc. VAT)"
 msgstr ""
 
 #: p3/templates/p3/cart.html:188

--- a/p3/templates/p3/cart.html
+++ b/p3/templates/p3/cart.html
@@ -146,7 +146,7 @@
                 <div class="button"><a href="#" class="cart-hotel-another-reservation" data-type="bed">{% trans "Add another" %}</a></div>
             </div>
             <div class="total">
-                {% trans "Hotel reservations total (inc. VAT & city tax)" %}: <b>€ 0</b>
+                {% trans "Hotel reservations total (inc. VAT)" %}: <b>€ 0</b>
             </div>
             {% else %}
             <h3>{% trans "Hotel rooms are currently sold out" %}</h3>
@@ -181,7 +181,7 @@
                 <div class="button"><a href="#" class="cart-hotel-another-reservation" data-type="room">{% trans "Add another" %}</a></div>
             </div>
             <div class="total">
-                {% trans "Hotel reservations total (inc. VAT & city tax)" %}: <b>€ 0</b>
+                {% trans "Hotel reservations total (inc. VAT)" %}: <b>€ 0</b>
             </div>
             {% else %}
             <h3>{% trans "Hotel rooms are currently sold out" %}</h3>


### PR DESCRIPTION
The dropdown box explains that the 4,50€/day tax is not included and will be paid separately, so the total price should not say that `city tax` is included.