### PR TITLE
Sponsors partitioned depending on sponsorship level #131

### DIFF
--- a/p3/static/p9/stylesheets/partials/_site.scss
+++ b/p3/static/p9/stylesheets/partials/_site.scss
@@ -342,6 +342,51 @@ header {
     }
 }
 
+.sponsor-container {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+}
+
+.sponsor-centered {
+	text-align: center;
+}
+
+.sponsor-100 {
+	min-width: 100%;
+}
+
+.sponsor-keystone {
+	width: 25%;
+}
+
+.sponsor-gold {
+	width: 25%;
+}
+
+.sponsor-silver {
+	width: 25%;
+}
+
+.sponsor-bronze {
+	width: 25%;
+}
+
+.sponsor-patron {
+	min-width: 25%;
+	max-width: 50%;
+}
+
+.sponsor-diversity {
+	min-width: 25%;
+	max-width: 50%;
+}
+
+.sponsor-startup {
+	min-width: 25%;
+	max-width: 100%;
+}
+
 .join-us {
     background-color: #202020;
     .help-text {

--- a/p3/static/p9/stylesheets/partials/_site.scss
+++ b/p3/static/p9/stylesheets/partials/_site.scss
@@ -343,48 +343,48 @@ header {
 }
 
 .sponsor-container {
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: center;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
 }
 
 .sponsor-centered {
-	text-align: center;
+    text-align: center;
 }
 
 .sponsor-100 {
-	min-width: 100%;
+    min-width: 100%;
 }
 
 .sponsor-keystone {
-	width: 25%;
+    width: 25%;
 }
 
 .sponsor-gold {
-	width: 25%;
+    width: 25%;
 }
 
 .sponsor-silver {
-	width: 25%;
+    width: 25%;
 }
 
 .sponsor-bronze {
-	width: 25%;
+    width: 25%;
 }
 
 .sponsor-patron {
-	min-width: 25%;
-	max-width: 50%;
+    min-width: 25%;
+    max-width: 50%;
 }
 
 .sponsor-diversity {
-	min-width: 25%;
-	max-width: 50%;
+    min-width: 25%;
+    max-width: 50%;
 }
 
 .sponsor-startup {
-	min-width: 25%;
-	max-width: 100%;
+    min-width: 25%;
+    max-width: 100%;
 }
 
 .join-us {

--- a/p3/templates/django_cms/p5_homepage.html
+++ b/p3/templates/django_cms/p5_homepage.html
@@ -67,18 +67,22 @@
         {% conference_sponsor as sponsors %}
         {%if sponsors %}
         <section>
-            <div class="grid-container">
-                <div class="grid-100">
+            <div class="grid-container justify-content-center sponsor-container">
+                <div class="sponsor-100">
                     <h2 class="border-title">{% trans 'Our Sponsors' %}</h2>
                 </div>
-                {% for s in sponsors %}
-                    <div class="grid-25">
-                        <div class="sponsor">
-                            <a href="{{ s.url }}"><img src="{{ s.logo|image_resized }}" alt="{{ s.alt_text }}" title="{% firstof s.title_text s.sponsor %}" width="190" height="90" /></a>
-                        </div>
-                    </div><!-- /grid -->
-                {% endfor %}
-                <div class="grid-25">
+                {% for group, spons in sponsors|sponsor_order:"keystone,gold,silver,bronze,patron,diversity,startup" %}
+				<div class="sponsor-{{ group }} sponsor-centered">
+					<h6>{{ group }}</h6>
+					{% for s in spons %}
+					<!--<span class="sponsor"> -->
+							<a href="{{ s.url }}">
+					<img src="{{ s.logo|image_resized }}" alt="{{ s.alt_text }}" title="{% firstof s.title_text s.sponsor %}" /></a>
+							<!--</span>-->
+					{% endfor %}
+                </div>
+				{% endfor %}
+                <div class="sponsor-100">
                     <div class="sponsor sponsor-wanted">
                         <a href="{% page_url 'sponsor' %}">{% trans 'Become a sponsor' %}</a>
                     </div>

--- a/p3/templates/django_cms/p5_homepage.html
+++ b/p3/templates/django_cms/p5_homepage.html
@@ -72,16 +72,16 @@
                     <h2 class="border-title">{% trans 'Our Sponsors' %}</h2>
                 </div>
                 {% for group, spons in sponsors|sponsor_order:"keystone,gold,silver,bronze,patron,diversity,startup" %}
-				<div class="sponsor-{{ group }} sponsor-centered">
-					<h6>{{ group }}</h6>
-					{% for s in spons %}
-					<!--<span class="sponsor"> -->
-							<a href="{{ s.url }}">
-					<img src="{{ s.logo|image_resized }}" alt="{{ s.alt_text }}" title="{% firstof s.title_text s.sponsor %}" /></a>
-							<!--</span>-->
-					{% endfor %}
+                <div class="sponsor-{{ group }} sponsor-centered">
+                    <h6>{{ group }}</h6>
+                    {% for s in spons %}
+                    <!--<span class="sponsor"> -->
+                            <a href="{{ s.url }}">
+                    <img src="{{ s.logo|image_resized }}" alt="{{ s.alt_text }}" title="{% firstof s.title_text s.sponsor %}" /></a>
+                            <!--</span>-->
+                    {% endfor %}
                 </div>
-				{% endfor %}
+                {% endfor %}
                 <div class="sponsor-100">
                     <div class="sponsor sponsor-wanted">
                         <a href="{% page_url 'sponsor' %}">{% trans 'Become a sponsor' %}</a>

--- a/p3/templatetags/p3.py
+++ b/p3/templatetags/p3.py
@@ -404,6 +404,33 @@ def com_com_registration(user):
         params[k] = v.encode('utf-8')
     return url + urllib.urlencode(params)
 
+
+@register.filter
+def sponsor_order(sponsors, levels):
+    levels = levels.split(',')
+    def _sponsor_level_key(s):
+        """Return position of sponsor class in levels list."""
+        # List of tag positions in _sponsor_levels
+        keys = [len(levels)-1]  # Default, when no tags are found
+        for t in (t.lower() for t in s['tags']):
+            try:
+                keys.append(levels.index(t))
+            except ValueError:
+                pass
+        return sorted(keys)[0]  # Get lowest position in the levels list
+
+    def get_first(x):  # itemgetter(0)
+        return x[0]
+
+    groups = []
+    pairs = ((_sponsor_level_key(s), s) for s in sponsors)
+    # Iterate sponsors grouped by level
+    for pos, spons in groupby(sorted(pairs, key=get_first), get_first):
+        # Append group of sponsors and their level (last level is the default)
+        groups.append((levels[pos], [s[1] for s in spons]))
+    return groups
+
+
 @register.inclusion_tag('p3/box_next_events.html', takes_context=True)
 def box_next_events(context):
     from conference.templatetags import conference as ctags


### PR DESCRIPTION
Risolve la #131 dividendo gli sponsor in colonne: non ho trovato un modo esteticamente decente per dare dimensione diverse agli sponsor in base al loro livello, quindi l'ho diviso in colonne.

È necessario che qualcuno compili gli scss per il deploy, perché io non ci son riuscito.